### PR TITLE
Normalized directory name

### DIFF
--- a/e621_dl.py
+++ b/e621_dl.py
@@ -73,7 +73,7 @@ def search_posts(
     posts = api.posts.search(formatted_tags, limit=max_posts, ignore_pagination=True)
     print(len(posts), "posts found")
     if _hardcoded_download_dir is None:
-        directory = download_dir / formatted_tags
+        directory = download_dir / normalize_directory_name(formatted_tags)
         directory.mkdir(exist_ok=True, parents=True)
     else:
         directory = _hardcoded_download_dir
@@ -329,6 +329,18 @@ def normalize_file_name(name: str, id: int) -> str:
         The normalized file name
     """
     return INVALID_FILE_CHAR.sub("", name).replace("\0", "") or f"e621_{id}"
+
+
+def normalize_directory_name(name: str) -> str:
+    """Makes directory name valid for both Windows and Unix systems
+
+    Args:
+        name: Original tags as a string
+
+    Returns:
+        The normalized directory name
+    """
+    return INVALID_FILE_CHAR.sub("-", name).replace("\0", "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added `normalize_directory_name` function for post searches to enable searching for "pool:<pool_id>" and saving them with a valid directory name.

It is not an elegant solution, but I had an issue with only being able to download 75 images from pools; with some searching, I found that there's a default limit defined in the e621 API that gets applied, because in `endpoints.Posts`'s `search()` the limit is set to None. By manually adding `limit = 1000`, 100 images will download. I didn't manage to find where that limitation comes in (probably undocumented API behavior), but found a workaround:  
searching for posts with `pool:<pool_id>` works. Obviously, the downloaded files' index number will be reversed, but otherwise should function up until the hard 320 limit set by the API, although this change for the code is needed, because it can't create a folder with `:` in its name.

